### PR TITLE
fb: verify email with token + tests + remove /api from api path

### DIFF
--- a/docs/swagger/auth.yml
+++ b/docs/swagger/auth.yml
@@ -1,4 +1,4 @@
-/api/v1/login:
+/v1/login:
   post:
     tags:
       - Authentication
@@ -19,7 +19,7 @@
     responses:
       200:
         description: Success
-/api/v1/logout:
+/v1/logout:
   post:
     tags:
       - Authentication
@@ -30,7 +30,7 @@
     responses:
       200:
         description: Success
-/api/v1/register:
+/v1/register:
   post:
     tags:
       - Authentication

--- a/start/routes.ts
+++ b/start/routes.ts
@@ -29,8 +29,8 @@ Route.group(() => {
   Route.post("/login", "AuthController.login").as("login");
   Route.post("/logout", "AuthController.logout").as("logout");
   Route.post("/register", "AuthController.register").as("register");
-  Route.get("/verify/:userId", "AuthController.verifyEmail").as("verifyEmail");
-}).prefix("api/v1");
+  Route.get("/verify", "AuthController.verifyEmail").as("verifyEmail");
+}).prefix("v1");
 
 Route.get("/dashboard", async ({ auth }) => {
   await auth.use("web").authenticate();

--- a/tests/functional/auth.spec.ts
+++ b/tests/functional/auth.spec.ts
@@ -2,6 +2,7 @@ import { test } from "@japa/runner";
 import Mail from "@ioc:Adonis/Addons/Mail";
 import User from "App/Models/User";
 import Database from "@ioc:Adonis/Lucid/Database";
+import Encryption from "@ioc:Adonis/Core/Encryption";
 import Route from "@ioc:Adonis/Core/Route";
 
 test.group("Auth", (group) => {
@@ -12,7 +13,7 @@ test.group("Auth", (group) => {
   test("mail sent when registering user", async ({ assert, client }) => {
     const mailer = Mail.fake();
 
-    await client.post("api/v1/register").json({
+    await client.post("v1/register").json({
       email: "test@studystorm.net",
       password: "test123",
       firstName: "Test",
@@ -39,7 +40,7 @@ test.group("Auth", (group) => {
 
     assert.exists(user);
 
-    const response = await client.post("api/v1/login").json({
+    const response = await client.post("v1/login").json({
       email: "test@studystorm.net",
       password: "test123",
     });
@@ -61,10 +62,13 @@ test.group("Auth", (group) => {
       lastName: "User",
     });
 
-    const verifyEmailUrl = Route.makeSignedUrl("verifyEmail", {
-      userId: user.id,
-    });
-
+    const verifyEmailUrl = Route.makeUrl(
+      "verifyEmail",
+      {},
+      {
+        qs: { key: Encryption.encrypt(user.id, "24 hours") },
+      }
+    );
     assert.exists(user);
 
     const response = await client.get(verifyEmailUrl);
@@ -87,9 +91,13 @@ test.group("Auth", (group) => {
       isEmailVerified: true,
     });
 
-    const verifyEmailUrl = Route.makeSignedUrl("verifyEmail", {
-      userId: user.id,
-    });
+    const verifyEmailUrl = Route.makeUrl(
+      "verifyEmail",
+      {},
+      {
+        qs: { key: Encryption.encrypt(user.id, "24 hours") },
+      }
+    );
 
     assert.exists(user);
 


### PR DESCRIPTION
- use token instead of signed url
- remove api from url: previously api/v1 but in production it will be `https://api.studystorm.net/api/v1` so api is redundant.