### PR TITLE
chore: disable swagger in production

### DIFF
--- a/config/swagger.ts
+++ b/config/swagger.ts
@@ -1,9 +1,10 @@
 import { SwaggerConfig } from "@ioc:Adonis/Addons/Swagger";
+import Application from "@ioc:Adonis/Core/Application";
 
 export default {
-  uiEnabled: true, //disable or enable swaggerUi route
+  uiEnabled: Application.inDev,
   uiUrl: "docs", // url path to swaggerUI
-  specEnabled: true, //disable or enable swagger.json route
+  specEnabled: Application.inDev,
   specUrl: "/swagger.json",
 
   middleware: [], // middlewares array, for protect your swagger docs and spec endpoints


### PR DESCRIPTION
Perhaps its better to hide private api documentation in production mode 