### PR TITLE
Chore/add db testing

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -12,7 +12,7 @@ PG_HOST=localhost
 PG_PORT=5432
 PG_USER=user
 PG_PASSWORD=password123
-PG_DB_NAME=studystorm
+PG_DB_NAME=studystorm_test
 
 S3_KEY=dummyKey
 S3_SECRET=dummySecret

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
         env:
           POSTGRESQL_USERNAME: user
           POSTGRESQL_PASSWORD: password123
-          POSTGRESQL_DATABASE: studystorm
+          POSTGRESQL_DATABASE: studystorm_test
         ports:
           - 5432:5432
     env:


### PR DESCRIPTION
You can setup the db with this command:
```bash
docker run --name sql-studystorm -p 5432:5432 -e POSTGRES_USER=user -e POSTGRES_PASSWORD=password123 -e POSTGRES_MULTIPLE_DATABASES=studystorm,studystorm_test gradescope/postgresql-multiple-databases:14.4
```
and keep studystorm in .env and use studystorm_test in env.test