### PR TITLE
Fix: use sync to update access right and add test

### DIFF
--- a/app/Controllers/Http/ClassroomsController.ts
+++ b/app/Controllers/Http/ClassroomsController.ts
@@ -103,11 +103,14 @@ export default class ClassroomsController {
 
     const user = await User.findByOrFail("email", payload.email);
 
-    await classroom
-      .related("users")
-      .pivotQuery()
-      .wherePivot("user_id", user.id)
-      .update("access_right", payload.accessRight);
+    await classroom.related("users").sync(
+      {
+        [user.id]: {
+          access_right: payload.accessRight,
+        },
+      },
+      false
+    );
 
     return response.ok({
       message: "User updated successfully",

--- a/tests/functional/classroomUser.spec.ts
+++ b/tests/functional/classroomUser.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { test } from "@japa/runner";
 import Database from "@ioc:Adonis/Lucid/Database";
 import { UserFactory } from "Database/factories/UserFactory";
@@ -122,6 +121,7 @@ test.group("Classrooms & Users", async (group) => {
 
   test("successfully update an user rights for a classroom", async ({
     client,
+    assert,
   }) => {
     const classroom = await ClassroomFactory.with("rootFolder")
       .apply("public")
@@ -145,6 +145,11 @@ test.group("Classrooms & Users", async (group) => {
     response.assertBodyContains({
       message: "User updated successfully",
     });
+    await classroom.load("users");
+    assert.equal(
+      classroom.users[1].$extras.pivot_access_right,
+      ClassroomAccessRight.RWD
+    );
   });
 
   test("successfully delete an user from classroom", async ({ client }) => {


### PR DESCRIPTION
```ts
await classroom.related("users").sync(
      {
        [user.id]: {
          access_right: payload.accessRight,
        },
      },
      false
    );
```
I switch user right with sync method instead of query builder
And add a test to check if the right change correctly
```ts
assert.equal(
      classroom.users[1].$extras.pivot_access_right,
      ClassroomAccessRight.RWD
    );
``` 